### PR TITLE
KAN-240 s3 path fix

### DIFF
--- a/src/main/java/com/GASB/slack_func/model/entity/WorkspaceConfig.java
+++ b/src/main/java/com/GASB/slack_func/model/entity/WorkspaceConfig.java
@@ -35,8 +35,8 @@ public class WorkspaceConfig {
     @Column(name = "alias")
     private String alias;
 
-    @Column(name = "validation", nullable = false)
-    private boolean validation;
+//    @Column(name = "validation", nullable = false)
+//    private boolean validation;
 
     @OneToMany(mappedBy = "config", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrgSaaS> orgSaaSList;

--- a/src/main/java/com/GASB/slack_func/service/file/FileUtil.java
+++ b/src/main/java/com/GASB/slack_func/service/file/FileUtil.java
@@ -53,7 +53,7 @@ public class FileUtil {
 
     @Value("${aws.s3.bucket}")
     private String bucketName;
-
+    private static final String HASH_ALGORITHM = "SHA-256";
     private final S3Client s3Client;
 
     @Transactional
@@ -83,7 +83,7 @@ public class FileUtil {
         String uploadedChannelPath = String.format("%s/%s/%s/%s/%s",orgName, saasName, workspaceName, channelName, uploadedUserName);
 
         // S3에 저장될 키 생성
-        String s3Key = String.format("%s/%s/%s/%s/%s",orgName, saasName, workspaceName, channelName, file.getName());
+        String s3Key = String.format("%s/%s/%s/%s/%s/%s",orgName, saasName, workspaceName, channelName, hash, file.getName());
 
         StoredFile storedFile = slackFileMapper.toStoredFileEntity(file, hash, s3Key);
 
@@ -115,14 +115,17 @@ public class FileUtil {
         }
     }
 
-    private String calculateHash(byte[] fileData) throws NoSuchAlgorithmException {
-        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    public static String calculateHash(byte[] fileData) throws NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
         byte[] hash = digest.digest(fileData);
-        StringBuilder hexString = new StringBuilder();
-        for (byte b : hash) {
+        return bytesToHex(hash);
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder hexString = new StringBuilder(2 * bytes.length);
+        for (byte b : bytes) {
             String hex = Integer.toHexString(0xff & b);
-            if (hex.length() == 1) hexString.append('0');
-            hexString.append(hex);
+            hexString.append(hex.length() == 1 ? "0" : "").append(hex);
         }
         return hexString.toString();
     }


### PR DESCRIPTION
s3에 업로드할때 해시값은 다르지만 파일명이 같은경우 파일이 덮어씌워져서 저장되기 때문에 vt업로드에 의도치 않은 오류가 발생하는 현상을 수정.